### PR TITLE
Show Selenium's Chrome Browser in Gitpod's VNC View

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,8 +1,0 @@
-FROM selenium/standalone-chrome-debug
-
-USER root
-
-RUN apt-get update \
-    && apt-get install -yq openjdk-11-jre-headless maven \
-    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
-

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,12 +1,15 @@
 image:
-  file: .gitpod.dockerfile
+  file: .gitpod/Dockerfile
+  context: .gitpod
 ports:
   - port: 6080
     onOpen: open-preview
+  - port: 4444
+    onOpen: open-browser
   - port: 5900
     onOpen: ignore
 tasks:
 - init: >
     mvn install
   command: >
-    mvn exec:java
+    mvn exec:java -Dexec.mainClass="com.applitools.quickstarts.BasicDemo"

--- a/.gitpod/Dockerfile
+++ b/.gitpod/Dockerfile
@@ -1,0 +1,29 @@
+FROM selenium/standalone-chrome-debug
+
+USER root
+
+RUN apt-get update \
+    && apt-get install -yq git openbox openjdk-11-jre-headless maven \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
+
+# add 'gitpod' user and permit "sudo -u seluser". 'seluser' is the standard user from selenium.
+RUN addgroup --gid 33333 gitpod \
+ && useradd --no-log-init --create-home --home-dir /home/gitpod --shell /bin/bash --uid 33333 --gid 33333 gitpod \
+ && echo "gitpod ALL=(seluser) NOPASSWD: ALL" >> /etc/sudoers
+
+# Install Novnc and register it with Supervisord. 
+RUN git clone https://github.com/novnc/noVNC.git /opt/novnc \
+    && git clone https://github.com/novnc/websockify /opt/novnc/utils/websockify
+COPY novnc-index.html /opt/novnc/index.html
+COPY novnc.conf /etc/supervisor/conf.d/
+EXPOSE 6080
+
+# Configure Supervisord to launch as daemon.
+RUN sed -i -e 's/nodaemon=true/nodaemon=false/g' /etc/supervisord.conf 
+
+USER gitpod
+ENV HOME=/home/gitpod
+ENV VNC_NO_PASSWORD=true
+
+# use .bashrc to launch Supervisord, in case it is not yet runnning
+RUN echo "[ ! -e /var/run/supervisor/supervisord.pid ] && /usr/bin/supervisord --configuration /etc/supervisord.conf" >> ~/.bashrc

--- a/.gitpod/novnc-index.html
+++ b/.gitpod/novnc-index.html
@@ -1,0 +1,1 @@
+<html><head><meta http-equiv="Refresh" content="0; url=vnc_lite.html"></head></html>

--- a/.gitpod/novnc.conf
+++ b/.gitpod/novnc.conf
@@ -1,0 +1,19 @@
+[program:novnc]
+priority=5
+directory=/opt/novnc/utils/
+command=/opt/novnc/utils/launch.sh --vnc "localhost:5900" --listen "6080"
+autostart=true
+autorestart=true
+startsecs=0
+startretries=0
+
+;Logs
+redirect_stderr=false
+stdout_logfile=/var/log/supervisor/novnc-stdout.log
+stderr_logfile=/var/log/supervisor/novnc-stderr.log
+stdout_logfile_maxbytes=50MB
+stderr_logfile_maxbytes=50MB
+stdout_logfile_backups=5
+stderr_logfile_backups=5
+stdout_capture_maxbytes=50MB
+stderr_capture_maxbytes=50MB


### PR DESCRIPTION
This change installs NoVNC, a JavaScript-based VNC client into the docker image. NoVNC is used to show the X11 desktop in Gitpod. Gitpod installs NoVNC in it's [workspace-full-vnc image](https://github.com/gitpod-io/workspace-images/tree/master/full-vnc), but we can't use that here, because we want to inherit from the `selenium` docker image.

With this change, after `mvn install` finishes, `mvn exec:java -Dexec.mainClass="com.applitools.quickstarts.BasicDemo"` is executed and we can see Selenium's Chrome browser for a few seconds (see screenshot) before `BasicDemo`  runs into error `eyes.openBase() failed`.

Try it: https://gitpod.io/#https://github.com/meysholdt/tutorial-selenium-java-basic

![image](https://user-images.githubusercontent.com/239422/56086321-e5f7d900-5e54-11e9-895a-9ccf51678a8d.png)
