### PR TITLE
Store JARs doenloaded by Maven in /workspace

### DIFF
--- a/.gitpod/Dockerfile
+++ b/.gitpod/Dockerfile
@@ -9,9 +9,11 @@ RUN apt-get update \
 # add 'gitpod' user and permit "sudo -u seluser". 'seluser' is the standard user from selenium.
 RUN addgroup --gid 33333 gitpod \
  && useradd --no-log-init --create-home --home-dir /home/gitpod --shell /bin/bash --uid 33333 --gid 33333 gitpod \
- && echo "gitpod ALL=(seluser) NOPASSWD: ALL" >> /etc/sudoers
+ && echo "gitpod ALL=(seluser) NOPASSWD: ALL" >> /etc/sudoers \
+ && mkdir "/home/gitpod/.m2" \
+ && printf '<settings>\n  <localRepository>/workspace/m2-repository/</localRepository>\n</settings>\n' > /home/gitpod/.m2/settings.xml
 
-# Install Novnc and register it with Supervisord. 
+# Install Novnc and register it with Supervisord.
 RUN git clone https://github.com/novnc/noVNC.git /opt/novnc \
     && git clone https://github.com/novnc/websockify /opt/novnc/utils/websockify
 COPY novnc-index.html /opt/novnc/index.html
@@ -19,7 +21,7 @@ COPY novnc.conf /etc/supervisor/conf.d/
 EXPOSE 6080
 
 # Configure Supervisord to launch as daemon.
-RUN sed -i -e 's/nodaemon=true/nodaemon=false/g' /etc/supervisord.conf 
+RUN sed -i -e 's/nodaemon=true/nodaemon=false/g' /etc/supervisord.conf
 
 USER gitpod
 ENV HOME=/home/gitpod


### PR DESCRIPTION
This ensures that Maven will not need to download JARs again after re-starting a workspace.