### PR TITLE
Clean up example code

### DIFF
--- a/src/test/java/com/applitools/quickstarts/BasicDemo.java
+++ b/src/test/java/com/applitools/quickstarts/BasicDemo.java
@@ -42,21 +42,15 @@ public class BasicDemo {
 		eyes = new Eyes(runner);
 
 		// Change the APPLITOOLS_API_KEY API key with yours:
-		eyes.setApiKey(System.getenv("APPLITOOLS_API_KEY"));
+		eyes.setApiKey("APPLITOOLS_API_KEY");
 
 		// set batch name
 		eyes.setBatch(batch);
 
-        // set proxy
-        eyes.setProxy(new AbstractProxySettings("http://ws-fwd-proxy:3129", 3219) {});
-
 		// Use Chrome browser
-        ChromeOptions options = new ChromeOptions();
-		Proxy proxy = new Proxy()
-			.setHttpProxy("http://ws-fwd-proxy:3129")
-			.setSslProxy("http://ws-fwd-proxy:3129");
-		options.setProxy(proxy);
-		driver = new ChromeDriver(options);
+		driver = new ChromeDriver(Util.newOptionsWithProxy());
+
+        Util.configureProxyIfNeeded(eyes);
 	}
 
 	@Test

--- a/src/test/java/com/applitools/quickstarts/Util.java
+++ b/src/test/java/com/applitools/quickstarts/Util.java
@@ -1,0 +1,37 @@
+package com.applitools.quickstarts;
+
+import com.applitools.eyes.AbstractProxySettings;
+import com.applitools.eyes.selenium.Eyes;
+import com.google.common.base.Strings;
+
+import org.openqa.selenium.Proxy;
+import org.openqa.selenium.chrome.ChromeOptions;
+
+class Util {
+
+    private static boolean IS_GITPOD = !Strings.isNullOrEmpty(System.getenv("GITPOD_INSTANCE_ID"));
+
+    /**
+     * if running in Gitpod, configure API Key and Proxy server.
+     */
+    public static void configureProxyIfNeeded(Eyes eyes) {
+        if (IS_GITPOD) {
+            eyes.setProxy(new AbstractProxySettings("http://ws-fwd-proxy:3129", 3219) {
+            });
+            eyes.setApiKey(System.getenv("APPLITOOLS_API_KEY"));
+        }
+    }
+
+    /**
+     * if running in Gitpod, configure Proxy server.
+     */
+    public static ChromeOptions newOptionsWithProxy() {
+        ChromeOptions options = new ChromeOptions();
+        if (IS_GITPOD) {
+            Proxy proxy = new Proxy().setHttpProxy("http://ws-fwd-proxy:3129").setSslProxy("http://ws-fwd-proxy:3129");
+            options.setProxy(proxy);
+        }
+        return options;
+    }
+
+}


### PR DESCRIPTION
* move Gitpod-specific proxy config into a Util class, so it doesn't confuse people who are interested in understanding the example
* allow the test to run just fine outside of Gitpod - by applying the proxy config only if we're in Gitpod. 