### PR TITLE
Hide config files from the file explorer in gitpod

### DIFF
--- a/.theia/settings.json
+++ b/.theia/settings.json
@@ -1,0 +1,12 @@
+{
+   "files.exclude": {
+      ".git": true,
+      ".theia": true,
+      ".gitignore": true,
+      ".gitpod.yml": true,
+      "**/.classpath": true,
+      "**/.project": true,
+      "**/.settings": true,
+      "**/.factorypath": true
+   }
+}


### PR DESCRIPTION
With this change, only the following files are shown:

![image](https://user-images.githubusercontent.com/239422/64735848-ac052e80-d4e9-11e9-96f1-d91fd22c928e.png)
