### PR TITLE
Add Junit

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 2. Import the project as a *Maven* project in Eclipse or IntelliJ.
 3. Set your API key in the _APPLITOOLS_API_KEY_ env variable. Get an API key by logging into Applitools > Person Icon > My API Key
-4. Click the 'Run' button in Eclipse/IntelliJ
+4. Run 'mvn -Dtest=BasicDemo test' or click the 'Run' button in Eclipse/IntelliJ
 
 Read more here: https://www.applitools.com/tutorials/selenium-java.html
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,16 @@
     <name>Java-tutorial</name>
     <url>http://maven.apache.org</url>
 
+    <build>
+	<plugins>
+		<plugin>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-surefire-plugin</artifactId>
+			<version>3.0.0-M4</version>
+		</plugin>
+	</plugins>
+    </build>
+
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -24,6 +34,12 @@
             <groupId>javax.activation</groupId>
             <artifactId>activation</artifactId>
             <version>1.1.1</version>
+        </dependency>
+	<dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.6.2</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/test/java/com/applitools/quickstarts/BasicDemo.java
+++ b/src/test/java/com/applitools/quickstarts/BasicDemo.java
@@ -9,10 +9,12 @@ import com.applitools.eyes.selenium.fluent.Target;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
+import org.junit.jupiter.api.Test;
 
 public class BasicDemo {
 
-	public static void main(String[] args) {
+	@Test
+        public void test() {
 
 		// Use Chrome browser
 		WebDriver driver = new ChromeDriver();
@@ -58,36 +60,30 @@ public class BasicDemo {
 	}
 
 	private static void TestDemoApp(WebDriver driver, Eyes eyes) {
-		try {
-			// Set AUT's name, test name and viewport size (width X height)
-			// We have set it to 800 x 600 to accommodate various screens. Feel free to
-			// change it.
-			eyes.open(driver, "Demo App", "Smoke Test", new RectangleSize(800, 600));
+		// Set AUT's name, test name and viewport size (width X height)
+		// We have set it to 800 x 600 to accommodate various screens. Feel free to
+		// change it.
+		eyes.open(driver, "Demo App", "Smoke Test", new RectangleSize(800, 600));
 
-			// Navigate the browser to the "ACME" demo app.
-			driver.get("https://demo.applitools.com");
+		// Navigate the browser to the "ACME" demo app.
+		driver.get("https://demo.applitools.com");
 
-			// To see visual bugs after the first run, use the commented line below instead.
-			// driver.get("https://demo.applitools.com/index_v2.html");
+		// To see visual bugs after the first run, use the commented line below instead.
+		// driver.get("https://demo.applitools.com/index_v2.html");
 
-			// Visual checkpoint #1 - Check the login page. using the fluent API
-			// https://applitools.com/docs/topics/sdk/the-eyes-sdk-check-fluent-api.html?Highlight=fluent%20api
-			eyes.check(Target.window().fully().withName("Login Window"));
+		// Visual checkpoint #1 - Check the login page. using the fluent API
+		// https://applitools.com/docs/topics/sdk/the-eyes-sdk-check-fluent-api.html?Highlight=fluent%20api
+		eyes.check(Target.window().fully().withName("Login Window"));
 
-			// This will create a test with two test steps.
-			driver.findElement(By.id("log-in")).click();
+		// This will create a test with two test steps.
+		driver.findElement(By.id("log-in")).click();
 
-			// Visual checkpoint #2 - Check the app page.
-			eyes.check(Target.window().fully().withName("App Window"));
+		// Visual checkpoint #2 - Check the app page.
+		eyes.check(Target.window().fully().withName("App Window"));
 
-			// End the test.
-			eyes.closeAsync();
+		// End the test.
+		eyes.closeAsync();
 
-		} catch (Exception e) {
-			// If the test was aborted before eyes.close was called, ends the test as
-			// aborted.
-			eyes.abortAsync();
-		}
 	}
 	
 	private static void tearDown(WebDriver driver, EyesRunner runner) {


### PR DESCRIPTION
Add dependency for JUnit and implement @Test to make possibility run test from CLI with 'mvn -Dtest=BasicDemo test'. Without this update I don't see way how to run tests from CLI, it's possible from IDE only. 
Also maven-surefire-plugin need for this.
Extra try-catch removed due to avoid test pass when it was exception. For example if not set right ApiKey test will pass without any exception message if try-catch remain.